### PR TITLE
Add coaching pipeline scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,3 +296,20 @@ If you use this in your research, please cite the paper:
   year={2023}
 }
 ```
+
+## Coaching Pipeline Example
+
+Helper scripts are available under `coaching_pipeline/` to demonstrate a minimal
+workflow for preparing retrieval‑augmented knowledge and LoRA training data.
+
+1. **Transcription** – batch transcribe folders of audio or video with
+   WhisperX. Each file produces a full transcript, a list of flagged sentences
+   when word confidence falls below 0.85 and word‑level timestamp JSON/SRT.
+2. **RAG Preparation** – split transcripts into ~500‑token chunks with YAML
+   headers and generate a `manifest.json` for indexing.
+3. **LoRA Preparation** – extract instruction/response pairs from diarized
+   transcripts and store them in `train.jsonl`.
+4. **LoRA Training** – run a small PEFT + TRL fine‑tuning loop to create LoRA
+   adapter weights for a base language model.
+
+Each script provides its own CLI. See the code for usage details.

--- a/coaching_pipeline/config_example.json
+++ b/coaching_pipeline/config_example.json
@@ -1,0 +1,13 @@
+{
+  "base_model": "microsoft/phi-2",
+  "r": 8,
+  "alpha": 16,
+  "dropout": 0.1,
+  "target_modules": ["q_proj", "v_proj"],
+  "trainer_args": {
+    "num_train_epochs": 1,
+    "per_device_train_batch_size": 1,
+    "logging_steps": 50,
+    "save_steps": 1000
+  }
+}

--- a/coaching_pipeline/lora_prep.py
+++ b/coaching_pipeline/lora_prep.py
@@ -1,0 +1,51 @@
+import argparse
+import json
+from pathlib import Path
+from typing import List, Dict
+
+
+def build_samples(json_path: Path) -> List[Dict[str, str]]:
+    with open(json_path, 'r', encoding='utf-8') as f:
+        data = json.load(f)
+    segments = data.get('segments', [])
+    samples = []
+    prev_text = None
+    prev_speaker = None
+    for seg in segments:
+        speaker = seg.get('speaker')
+        text = seg.get('text', '').strip()
+        if speaker and speaker.lower().startswith('peter'):
+            if prev_text and prev_speaker and prev_speaker != speaker:
+                samples.append({
+                    'instruction': f'{prev_speaker}: {prev_text}',
+                    'output': f'{speaker}: {text}'
+                })
+        prev_text = text
+        prev_speaker = speaker
+    return samples
+
+
+def process_folder(in_dir: Path, out_file: Path, limit: int = 50000):
+    all_samples = []
+    for file in sorted(in_dir.glob('*_timestamps.json')):
+        all_samples.extend(build_samples(file))
+        if len(all_samples) >= limit:
+            break
+    with open(out_file, 'w', encoding='utf-8') as f:
+        for s in all_samples[:limit]:
+            json.dump(s, f, ensure_ascii=False)
+            f.write('\n')
+
+
+def cli(argv: List[str] = None) -> None:
+    parser = argparse.ArgumentParser(description='Prepare LoRA training data')
+    parser.add_argument('input', type=Path, help='Folder with timestamp jsons')
+    parser.add_argument('output', type=Path, help='Output train.jsonl path')
+    parser.add_argument('--limit', type=int, default=50000, help='Max samples')
+    args = parser.parse_args(argv)
+
+    process_folder(args.input, args.output, args.limit)
+
+
+if __name__ == '__main__':
+    cli()

--- a/coaching_pipeline/lora_train.py
+++ b/coaching_pipeline/lora_train.py
@@ -1,0 +1,49 @@
+import argparse
+import json
+from pathlib import Path
+from typing import Dict
+
+import torch
+from datasets import load_dataset
+from peft import LoraConfig, PeftModel
+from transformers import AutoModelForCausalLM, AutoTokenizer
+from trl import SFTTrainer
+
+
+def train(train_path: Path, config: Dict, out_dir: Path):
+    dataset = load_dataset('json', data_files=str(train_path))['train']
+    model_name = config.get('base_model', 'microsoft/phi-2')
+    model = AutoModelForCausalLM.from_pretrained(model_name, load_in_4bit=True)
+    tokenizer = AutoTokenizer.from_pretrained(model_name)
+    lora_config = LoraConfig(
+        r=config.get('r', 8),
+        lora_alpha=config.get('alpha', 16),
+        lora_dropout=config.get('dropout', 0.1),
+        target_modules=config.get('target_modules', ['q_proj', 'v_proj'])
+    )
+    trainer = SFTTrainer(
+        model=model,
+        train_dataset=dataset,
+        peft_config=lora_config,
+        dataset_text_field='text',
+        max_seq_length=tokenizer.model_max_length,
+        args=config.get('trainer_args', {})
+    )
+    trainer.train()
+    trainer.model.save_pretrained(out_dir)
+
+
+def cli(argv=None):
+    parser = argparse.ArgumentParser(description='Train LoRA model')
+    parser.add_argument('train_file', type=Path, help='train.jsonl file')
+    parser.add_argument('config', type=Path, help='json config')
+    parser.add_argument('output', type=Path, help='output directory')
+    args = parser.parse_args(argv)
+
+    with open(args.config) as f:
+        cfg = json.load(f)
+    train(args.train_file, cfg, args.output)
+
+
+if __name__ == '__main__':
+    cli()

--- a/coaching_pipeline/rag_prep.py
+++ b/coaching_pipeline/rag_prep.py
@@ -1,0 +1,78 @@
+import argparse
+import json
+import uuid
+from pathlib import Path
+from typing import List, Dict
+
+import nltk
+from nltk.tokenize import sent_tokenize, word_tokenize
+
+nltk.download('punkt', quiet=True)
+
+
+def chunk_transcript(text: str, max_tokens: int = 500) -> List[str]:
+    sentences = sent_tokenize(text)
+    chunks = []
+    current = []
+    tokens = 0
+    for sent in sentences:
+        words = word_tokenize(sent)
+        if tokens + len(words) > max_tokens and current:
+            chunks.append(' '.join(current))
+            current = []
+            tokens = 0
+        current.append(sent)
+        tokens += len(words)
+    if current:
+        chunks.append(' '.join(current))
+    return chunks
+
+
+def make_header(text: str, source: str) -> Dict[str, str]:
+    words = word_tokenize(text)
+    title = ' '.join(words[:8])
+    summary = ' '.join(words[:50])
+    return {
+        'id': str(uuid.uuid4()),
+        'title': title,
+        'summary': summary,
+        'source': source,
+    }
+
+
+def process_transcript(path: Path, out_dir: Path, manifest: List[Dict]):
+    with open(path, 'r', encoding='utf-8') as f:
+        text = f.read()
+    chunks = chunk_transcript(text)
+    for chunk in chunks:
+        header = make_header(chunk, path.name)
+        chunk_file = out_dir / f"{header['id']}.md"
+        with open(chunk_file, 'w', encoding='utf-8') as f:
+            f.write('---\n')
+            for k, v in header.items():
+                f.write(f"{k}: {v}\n")
+            f.write('---\n\n')
+            f.write(chunk)
+        manifest.append({**header, 'file': chunk_file.name})
+
+
+def build_rag_chunks(in_dir: Path, out_dir: Path):
+    out_dir.mkdir(parents=True, exist_ok=True)
+    manifest = []
+    for file in sorted(in_dir.glob("*_full_transcript.txt")):
+        process_transcript(file, out_dir, manifest)
+    with open(out_dir / 'manifest.json', 'w', encoding='utf-8') as f:
+        json.dump(manifest, f, ensure_ascii=False, indent=2)
+
+
+def cli(argv: List[str] = None) -> None:
+    parser = argparse.ArgumentParser(description="Prepare RAG chunks")
+    parser.add_argument("input", type=Path, help="Folder with transcripts")
+    parser.add_argument("output", type=Path, help="Output folder")
+    args = parser.parse_args(argv)
+
+    build_rag_chunks(args.input, args.output)
+
+
+if __name__ == "__main__":
+    cli()

--- a/coaching_pipeline/transcribe.py
+++ b/coaching_pipeline/transcribe.py
@@ -1,0 +1,76 @@
+import argparse
+import json
+import os
+from pathlib import Path
+from typing import List
+
+import nltk
+import whisperx
+
+nltk.download('punkt', quiet=True)
+
+CONFIDENCE_THRESHOLD = 0.85
+
+
+def flag_low_confidence(segment: dict) -> bool:
+    """Return True if any word score is below threshold."""
+    for w in segment.get("words", []):
+        if w.get("score", 1.0) < CONFIDENCE_THRESHOLD:
+            return True
+    return False
+
+
+def process_file(path: Path, out_dir: Path, model, device: str = "cuda") -> None:
+    """Transcribe a single file and write outputs."""
+    audio = whisperx.load_audio(str(path))
+    result = model.transcribe(audio, batch_size=16)
+    align_model, metadata = whisperx.load_align_model(result["language"], device)
+    result = whisperx.align(result["segments"], align_model, metadata, audio, device)
+
+    base = out_dir / path.stem
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    # write full transcript
+    with open(base.with_suffix("_full_transcript.txt"), "w", encoding="utf-8") as f:
+        for seg in result["segments"]:
+            f.write(seg["text"].strip() + "\n")
+
+    # write flagged sentences
+    with open(base.with_suffix("_flagged_sentences.txt"), "w", encoding="utf-8") as f:
+        for seg in result["segments"]:
+            if flag_low_confidence(seg):
+                f.write(seg["text"].strip() + "\n")
+
+    # save word-level timestamps JSON
+    with open(base.with_suffix("_timestamps.json"), "w", encoding="utf-8") as f:
+        json.dump(result, f, ensure_ascii=False, indent=2)
+
+    # also save srt subtitles
+    writer = whisperx.utils.get_writer("srt", str(out_dir))
+    writer(result, str(path), {})
+
+
+
+def transcribe_folder(in_dir: Path, out_dir: Path, model_name: str = "large-v2", device: str = "cuda"):
+    model = whisperx.load_model(model_name, device, compute_type="float16")
+    for file in sorted(in_dir.iterdir()):
+        if file.suffix.lower() not in {".mp4", ".wav"}:
+            continue
+        print(f"Transcribing {file.name}...")
+        process_file(file, out_dir, model, device)
+    del model
+
+
+def cli(argv: List[str] = None) -> None:
+    parser = argparse.ArgumentParser(description="Batch transcribe with WhisperX")
+    parser.add_argument("input", type=Path, help="Folder of audio/video files")
+    parser.add_argument("output", type=Path, help="Output folder")
+    parser.add_argument("--model", default="large-v2", help="Whisper model name")
+    parser.add_argument("--device", default="cuda", help="cuda or cpu")
+    args = parser.parse_args(argv)
+
+    transcribe_folder(args.input, args.output, args.model, args.device)
+
+
+if __name__ == "__main__":
+    cli()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+whisperx>=3.3.4
+pandas
+nltk
+transformers
+peft
+trl
+datasets
+torch


### PR DESCRIPTION
## Summary
- add simple end-to-end pipeline under `coaching_pipeline/`
- provide transcription, RAG, LoRA prep and training scripts
- document new pipeline in README
- add example training config and requirements

## Testing
- `python -m py_compile coaching_pipeline/*.py`